### PR TITLE
Removed two duplicated anchors

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9898,7 +9898,7 @@ components:
           x-oaiTypeLabel: map
           nullable: true
         temperature:
-          description: &run_temperature_description |
+          description: *run_temperature_description |
             What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
           type: number
           minimum: 0
@@ -9913,7 +9913,7 @@ components:
           default: 1
           example: 1
           nullable: true
-          description: &run_top_p_description |
+          description: *run_top_p_description |
             An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
 
             We generally recommend altering this or temperature but not both.
@@ -10004,7 +10004,7 @@ components:
           default: 1
           example: 1
           nullable: true
-          description: &run_top_p_description |
+          description: *run_top_p_description |
             An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
 
             We generally recommend altering this or temperature but not both.
@@ -10446,7 +10446,7 @@ components:
           default: 1
           example: 1
           nullable: true
-          description: &run_top_p_description |
+          description: *run_top_p_description |
             An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
 
             We generally recommend altering this or temperature but not both.


### PR DESCRIPTION
Removed two duplicated anchors: `run_temperature_description` and `run_top_p_description`.